### PR TITLE
Add Transaction utils

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,16 @@
+# Copyright 2020 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+**/compiled_protos*

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,28 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".ts"]
+      }
+    }
+  },
+  "env": {
+    "es6": true,
+    "jest": true,
+    "browser": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
+  "rules": {
+    "import/no-default-export": 2,
+    "import/prefer-default-export": 0
+  },
+  "extends": [
+    "plugin:@typescript-eslint/recommended",
+    "airbnb",
+    "plugin:prettier/recommended"
+  ]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -17,12 +17,11 @@
     "ecmaVersion": 2020
   },
   "rules": {
-    "import/no-default-export": 2,
-    "import/prefer-default-export": 0
+    "import/prefer-default-export": 0,
+    "@typescript-eslint/interface-name-prefix": 0
   },
   "extends": [
     "plugin:@typescript-eslint/recommended",
-    "airbnb",
     "plugin:prettier/recommended"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+node_modules/
+**/compiled_protos*
+
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+/MAINTAINERS.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "repository": "https://github.com/hyperledger/transact-sdk-javascript.git",
   "license": "Apache-2.0",
   "scripts": {
+    "format": "prettier --write \"**/*.+(ts|*rc|json|js)\"",
     "lint": "eslint src/**/**/**/*"
   },
   "devDependencies": {
@@ -23,6 +24,7 @@
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-import": "^2.19.1",
-    "eslint-plugin-prettier": "^3.1.2"
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
     "eslint": "^6.8.0",
-    "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1",
+    "typescript": "^3.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,13 @@
   "repository": "https://github.com/hyperledger/transact-sdk-javascript.git",
   "license": "Apache-2.0",
   "scripts": {
+    "postinstall": "npm run generate-proto-files",
     "format": "prettier --write \"**/*.+(ts|*rc|json|js)\"",
-    "lint": "eslint src/**/**/**/*"
+    "lint": "eslint src/**/**/**/*",
+    "generate-proto-files": "node scripts/compile_protobuf.js ./protos"
+  },
+  "dependencies": {
+    "protobufjs": "^6.8.8"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.14.0",
@@ -25,7 +30,10 @@
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
+    "fs": "0.0.1-security",
+    "path": "^0.12.7",
     "prettier": "^1.19.1",
+    "process": "^0.11.10",
     "typescript": "^3.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,17 @@
   ],
   "homepage": "https://www.hyperledger.org/projects/transact",
   "repository": "https://github.com/hyperledger/transact-sdk-javascript.git",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "scripts": {
+    "lint": "eslint src/**/**/**/*"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.14.0",
+    "@typescript-eslint/parser": "^2.14.0",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-prettier": "^6.9.0",
+    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-prettier": "^3.1.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "generate-proto-files": "node scripts/compile_protobuf.js ./protos"
   },
   "dependencies": {
-    "protobufjs": "^6.8.8"
+    "@types/secp256k1": "^3.5.0",
+    "crypto": "^1.0.1",
+    "protobufjs": "^6.8.8",
+    "secp256k1": "^3.8.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "postinstall": "npm run generate-proto-files",
     "format": "prettier --write \"**/*.+(ts|*rc|json|js)\"",
     "lint": "eslint src/**/**/**/*",
+    "test": "jest",
     "generate-proto-files": "node scripts/compile_protobuf.js ./protos"
   },
   "dependencies": {
@@ -26,16 +27,23 @@
     "secp256k1": "^3.8.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.7.7",
+    "@babel/preset-env": "^7.7.7",
+    "@babel/preset-typescript": "^7.7.7",
+    "@types/jest": "^24.0.25",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
+    "babel-jest": "^24.9.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "fs": "0.0.1-security",
+    "jest": "^24.9.0",
     "path": "^0.12.7",
     "prettier": "^1.19.1",
     "process": "^0.11.10",
+    "ts-jest": "^24.2.0",
     "typescript": "^3.7.4"
   }
 }

--- a/protos/batch.proto
+++ b/protos/batch.proto
@@ -1,0 +1,47 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "transaction.proto";
+
+message BatchHeader {
+    // Public key for the client that signed the BatchHeader
+    string signer_public_key = 1;
+
+    // List of transaction.header_signatures that match the order of
+    // transactions required for the batch
+    repeated string transaction_ids = 2;
+}
+
+message Batch {
+    // The serialized version of the BatchHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // A list of the transactions that match the list of
+    // transaction_ids listed in the batch header
+    repeated Transaction transactions = 3;
+
+    // A debugging flag which indicates this batch should be traced through the
+    // system, resulting in a higher level of debugging output.
+    bool trace = 4;
+}
+
+message BatchList {
+    repeated Batch batches = 1;
+}

--- a/protos/command.proto
+++ b/protos/command.proto
@@ -1,0 +1,121 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+// A transaction payload for the Command Family
+message CommandPayload {
+    // The list of commands to execute
+    repeated Command commands = 1;
+}
+
+// A key-value pair where the value is a bytes field.
+message BytesEntry {
+    // The key, for instance a state address or a string value, depending on
+    // the target of the entry.
+    string key = 1;
+    // The byte value to be stored
+    bytes value = 2;
+}
+
+// The list of state keys to be retrieved via a GET_STATE command.
+message GetState {
+    // a non-empty list of valid state keys
+    repeated string state_keys = 1;
+}
+
+// The list of state entries to be set via a SET_STATE command.
+message SetState {
+    // a non-empty list of BytesEntry instances, where the key field is a
+    // valid state key.
+    repeated BytesEntry state_writes = 1;
+}
+
+// The list of state keys to be deleted via a DELETE_STATE command.
+message DeleteState {
+    // a non-empty list of valid state keys
+    repeated string state_keys = 1;
+}
+
+// Describes an event to add to the receipt via an ADD_EVENT command.
+message AddEvent {
+    // The event type
+    string event_type = 1;
+    // The attribute entries
+    repeated BytesEntry attributes = 2;
+    // Arbitrary opaque event data
+    bytes data = 3;
+}
+
+// The opaque byte data to add to the receipt via an ADD_RECEIPT_DATA
+// command.
+message AddReceiptData {
+    // a non-empty byte array
+    bytes receipt_data = 1;
+}
+
+// The duration and method of sleep to apply during a SLEEP command.
+message Sleep {
+    enum SleepType {
+        // This will wait, releasing cpu utilization to other processes
+        WAIT = 0;
+        // This will consume a cpu core for the specified time
+        BUSY_WAIT = 1;
+    }
+
+    // The duration to sleep, in milliseconds
+    uint32 duration_millis = 1;
+    SleepType sleep_type = 2;
+}
+
+// The details to return on an RETURN_INVALID command.
+message ReturnInvalid {
+    // An optional error message
+    string error_message = 1;
+}
+
+// The details to return on an RETURN_INTERNAL_ERROR command.
+message ReturnInternalError {
+    // An optional error message
+    string error_message = 1;
+}
+
+// A command to be executed
+message Command {
+    enum CommandType {
+        UNSET_COMMAND_TYPE = 0;
+        GET_STATE = 1;
+        SET_STATE = 2;
+        DELETE_STATE = 3;
+        ADD_EVENT = 4;
+        ADD_RECEIPT_DATA = 5;
+        SLEEP = 6;
+        RETURN_INVALID = 7;
+        RETURN_INTERNAL_ERROR = 8;
+    }
+
+    // The type of the command, which indicates which of the following
+    // fields will be set.
+    CommandType command_type = 1;
+
+    GetState get_state = 2;
+    SetState set_state = 3;
+    DeleteState delete_state = 4;
+    AddEvent add_event = 5;
+    AddReceiptData add_receipt_data = 6;
+    Sleep sleep = 7;
+    ReturnInvalid return_invalid = 8;
+    ReturnInternalError return_internal_error = 9;
+}

--- a/protos/events.proto
+++ b/protos/events.proto
@@ -1,0 +1,61 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message Event {
+  // Used to subscribe to events and servers as a hint for how to deserialize
+  // event_data and what pairs to expect in attributes.
+  string event_type = 1;
+
+  // Transparent data defined by the event_type.
+  message Attribute {
+    string key = 1;
+    string value = 2;
+  }
+  repeated Attribute attributes = 2;
+
+  // Opaque data defined by the event_type.
+  bytes  data = 3;
+}
+
+message EventList {
+    repeated Event events = 1;
+}
+
+message EventFilter {
+    // EventFilter is used when subscribing to events to limit the events
+    // received within a given event type. See
+    // validator/server/events/subscription.py for further explanation.
+    string key = 1;
+    string match_string = 2;
+
+    enum FilterType {
+      FILTER_TYPE_UNSET = 0;
+      SIMPLE_ANY = 1;
+      SIMPLE_ALL = 2;
+      REGEX_ANY  = 3;
+      REGEX_ALL  = 4;
+    }
+    FilterType filter_type = 3;
+}
+
+message EventSubscription {
+    // EventSubscription is used when subscribing to events to specify the type
+    // of events being subscribed to, along with any additional filters. See
+    // validator/server/events/subscription.py for further explanation.
+    string event_type = 1;
+    repeated EventFilter filters = 2;
+}

--- a/protos/key_value_state.proto
+++ b/protos/key_value_state.proto
@@ -1,0 +1,48 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message StateEntryValue {
+  enum ValueType {
+    TYPE_UNSET = 0;
+    INT64 = 1;
+    INT32 = 2;
+    UINT64 = 3;
+    UINT32 = 4;
+    STRING = 5;
+    BYTES = 6;
+  }
+  string key = 1;
+
+  ValueType value_type = 2;
+
+  int32 int32_value = 3;
+  int64 int64_value = 4;
+  uint32 uint32_value = 5;
+  uint64 uint64_value = 6;
+  string string_value = 7;
+  bytes bytes_value = 8;
+}
+
+
+message StateEntry {
+  string normalized_key = 1;
+  repeated StateEntryValue state_entry_values = 2;
+}
+
+message StateEntryList {
+  repeated StateEntry entries = 1;
+}

--- a/protos/merkle.proto
+++ b/protos/merkle.proto
@@ -1,0 +1,39 @@
+// Copyright 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+syntax = "proto3";
+
+
+// An Entry in the change log for a given state root.
+message ChangeLogEntry {
+    // A state root that succeed this root.
+    message Successor {
+        // A root hash of a merkle trie based of off this root.
+        bytes successor = 1;
+
+        // The keys (i.e. hashes) that were replaced (i.e. deleted) by this
+        // successor.  These may be deleted during pruning.
+        repeated bytes deletions = 2;
+    }
+
+    // A root hash of a merkle trie this tree was based off.
+    bytes parent = 1;
+
+    // The hashes that were added for this root. These may be deleted during
+    // pruning, if this root is being abandoned.
+    repeated bytes additions = 2;
+
+    // The list of successors.
+    repeated Successor successors = 3;
+}

--- a/protos/sabre_payload.proto
+++ b/protos/sabre_payload.proto
@@ -1,0 +1,153 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+message SabrePayload {
+  enum Action {
+    ACTION_UNSET = 0;
+    CREATE_CONTRACT = 1;
+    DELETE_CONTRACT = 2;
+    EXECUTE_CONTRACT = 3;
+    CREATE_CONTRACT_REGISTRY = 4;
+    DELETE_CONTRACT_REGISTRY = 5;
+    UPDATE_CONTRACT_REGISTRY_OWNERS = 6;
+    CREATE_NAMESPACE_REGISTRY = 7;
+    DELETE_NAMESPACE_REGISTRY = 8;
+    UPDATE_NAMESPACE_REGISTRY_OWNERS = 9;
+    CREATE_NAMESPACE_REGISTRY_PERMISSION = 10;
+    DELETE_NAMESPACE_REGISTRY_PERMISSION = 11;
+    CREATE_SMART_PERMISSION = 12;
+    UPDATE_SMART_PERMISSION= 13;
+    DELETE_SMART_PERMISSION = 14;
+  }
+
+  Action action = 1;
+
+  CreateContractAction create_contract = 2;
+  DeleteContractAction delete_contract = 3;
+  ExecuteContractAction execute_contract = 4;
+
+  CreateContractRegistryAction create_contract_registry = 5;
+  DeleteContractRegistryAction delete_contract_registry = 6;
+  UpdateContractRegistryOwnersAction update_contract_registry_owners = 7;
+
+  CreateNamespaceRegistryAction create_namespace_registry = 8;
+  DeleteNamespaceRegistryAction delete_namespace_registry = 9;
+  UpdateNamespaceRegistryOwnersAction update_namespace_registry_owners = 10;
+  CreateNamespaceRegistryPermissionAction create_namespace_registry_permission = 11;
+  DeleteNamespaceRegistryPermissionAction delete_namespace_registry_permission = 12;
+
+  CreateSmartPermissionAction create_smart_permission = 13;
+  UpdateSmartPermissionAction update_smart_permission = 14;
+  DeleteSmartPermissionAction delete_smart_permission = 15;
+}
+
+// creates a Contract and updates ContractRegistry with a version entry
+message CreateContractAction {
+  string name = 1;
+  string version = 2;
+  repeated string inputs = 3;
+  repeated string outputs = 4;
+  bytes contract = 5;
+}
+
+// removes a Contract and removes the version entry from ContractRegistry
+message DeleteContractAction {
+  string name = 1;
+  string version = 2;
+}
+
+// executes the contract
+message ExecuteContractAction {
+  string name = 1;
+  string version = 2;
+  repeated string inputs = 3;
+  repeated string outputs = 4;
+  bytes payload = 5;
+}
+
+// creates the ContractRegistry in state with no Versions
+message CreateContractRegistryAction {
+  string name = 1;
+  repeated string owners = 2;
+}
+
+// deletes the ContractRegistry associated with 'name'
+// only if it contains no versions
+message DeleteContractRegistryAction {
+  string name = 1;
+}
+
+// updates the owners field in the ContractRegistry associated with 'name'
+message UpdateContractRegistryOwnersAction {
+  string name = 1;
+  repeated string owners = 2;
+}
+
+// creates the ContractRegistry in state with no Permissions
+message CreateNamespaceRegistryAction {
+  string namespace = 1;
+  repeated string owners = 2;
+}
+
+// deletes the NamespaceRegistry associated with 'namespace'
+// only if it contains no permissions
+message DeleteNamespaceRegistryAction {
+  string namespace = 1;
+}
+
+// updates the owners field in the NamespaceRegistry associated with 'namespace'
+message UpdateNamespaceRegistryOwnersAction {
+  string namespace = 1;
+  repeated string owners = 2;
+}
+
+// adds a permission entry to the NamespaceRegistry associated with 'namespace'
+message CreateNamespaceRegistryPermissionAction {
+  string namespace = 1;
+  string contract_name = 2;
+  bool read = 3;
+  bool write = 4;
+}
+
+// removes a permission entry to the NamespaceRegistry associated with
+// 'namespace'
+message DeleteNamespaceRegistryPermissionAction {
+  string namespace = 1;
+  string contract_name = 2;
+}
+
+// Creates a smart permission
+message CreateSmartPermissionAction {
+  string name = 1;
+  // ID of organization that owns the smart permission
+  string org_id = 2;
+  bytes function = 3;
+}
+
+// Updates a smart permission
+message UpdateSmartPermissionAction {
+  string name = 1;
+  // ID of organization that owns the smart permission
+  string org_id = 2;
+  bytes function = 3;
+}
+
+// Deletes  a smart permission
+message DeleteSmartPermissionAction {
+  string name = 1;
+  // ID of organization that owns the smart permission
+  string org_id = 2;
+}

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -1,0 +1,69 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message TransactionHeader {
+    // Public key for the client who added this transaction to a batch
+    string batcher_public_key = 1;
+
+    // A list of transaction signatures that describe the transactions that
+    // must be processed before this transaction can be valid
+    repeated string dependencies = 2;
+
+    // The family name correlates to the transaction processor's family name
+    // that this transaction can be processed on, for example 'intkey'
+    string family_name = 3;
+
+    // The family version correlates to the transaction processor's family
+    // version that this transaction can be processed on, for example "1.0"
+    string family_version = 4;
+
+    // A list of addresses that are given to the context manager and control
+    // what addresses the transaction processor is allowed to read from.
+    repeated string inputs = 5;
+
+    // A random string that provides uniqueness for transactions with
+    // otherwise identical fields.
+    string nonce = 6;
+
+    // A list of addresses that are given to the context manager and control
+    // what addresses the transaction processor is allowed to write to.
+    repeated string outputs = 7;
+
+    //The sha512 hash of the encoded payload
+    string payload_sha512 = 9;
+
+    // Public key for the client that signed the TransactionHeader
+    string signer_public_key = 10;
+}
+
+message Transaction {
+    // The serialized version of the TransactionHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // The payload is the encoded family specific information of the
+    // transaction. Example cbor({'Verb': verb, 'Name': name,'Value': value})
+    bytes payload = 3;
+}
+
+// A simple list of transactions that needs to be serialized before
+// it can be transmitted to a batcher.
+message TransactionList {
+    repeated Transaction transactions = 1;
+}

--- a/protos/transaction_receipt.proto
+++ b/protos/transaction_receipt.proto
@@ -1,0 +1,68 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "events.proto";
+
+message TransactionReceipt {
+  enum Result {
+    RESULT_UNSET = 0;
+    VALID = 1;
+    INVALID = 2;
+  }
+
+  // FIELDS FOR ALL RECEIPTS
+
+  string transaction_id = 4;
+  Result result = 5;
+
+  // FIELDS FOR VALID RECEIPTS
+
+  // State changes made by this transaction
+  // StateChange is defined in protos/transaction_receipt.proto
+  repeated StateChange state_changes = 1;
+  // Events fired by this transaction
+  // Event is defined in protos/events.proto
+  repeated Event events = 2;
+  // Transaction family defined data
+  repeated bytes data = 3;
+
+  // FIELDS FOR INVALID RECEIPTS
+
+  // Human-readable reason for why the transaction was invalid
+  string error_message = 6;
+  // Transaction-specific error data that can be interpreted by clients familiar
+  // with the transaction family
+  bytes error_data = 7;
+}
+
+//  StateChange objects have the type of SET, which is either an insert or
+//  update, or DELETE. Items marked as a DELETE will have no byte value.
+message StateChange {
+    enum Type {
+        TYPE_UNSET = 0;
+        SET = 1;
+        DELETE = 2;
+    }
+    string address = 1;
+    bytes value = 2;
+    Type type = 3;
+}
+
+// A collection of state changes.
+message StateChangeList {
+    repeated StateChange state_changes = 1;
+}

--- a/scripts/compile_protobuf.js
+++ b/scripts/compile_protobuf.js
@@ -1,0 +1,56 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const fs = require('fs');
+const pbjs = require('protobufjs/cli/pbjs');
+const pbts = require('protobufjs/cli/pbts');
+const process = require('process');
+
+const path = require('path');
+
+const protoDir = process.argv[2];
+
+const files = fs.readdirSync(protoDir).map(f => path.resolve(protoDir, f));
+
+pbjs.main(
+  [
+    '-t',
+    'static-module',
+    '-w',
+    'commonjs',
+    '-o',
+    'src/compiled_protos.js',
+    ...files
+  ],
+  function handleJsCompileError(err) {
+    if (err) {
+      console.error(`Error compiling protobuf bundle: ${err}`);
+    } else {
+      console.log('Sucessfully created protobuf bundle');
+    }
+  }
+);
+
+pbts.main(
+  ['-o', 'src/compiled_protos.d.ts', 'src/compiled_protos.js'],
+  function handleJsCompileError(err) {
+    if (err) {
+      console.error(`Error compiling protobuf typings: ${err}`);
+    } else {
+      console.log('Sucessfully created protobuf typings');
+    }
+  }
+);

--- a/src/transactions/addressing.ts
+++ b/src/transactions/addressing.ts
@@ -1,0 +1,58 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import crypto from 'crypto';
+
+// The namespace registry prefix for global state (00ec00)
+const NAMESPACE_REGISTRY_PREFIX = '00ec00';
+
+// The contract prefix for global state (00ec02)
+const CONTRACT_PREFIX = '00ec02';
+
+// The contract registry prefix for global state (00ec01)
+const CONTRACT_REGISTRY_PREFIX = '00ec01';
+
+// The Sawtooth Sabre transaction family name (sabre)
+export const SABRE_FAMILY_NAME = 'sabre';
+// The Sawtooth Sabre transaction family version (0.4)
+export const SABRE_FAMILY_VERSION = '0.4';
+
+export function calculateNamespaceRegistryAddress(namespace: string): string {
+  const prefix = namespace.slice(0, 6);
+  const hash = crypto
+    .createHash('sha512')
+    .update(prefix)
+    .digest('hex')
+    .slice(0, 64);
+  return `${NAMESPACE_REGISTRY_PREFIX}${hash}`;
+}
+
+export function computeContractAddress(name: string, version: string): string {
+  const input = `${name},${version}`;
+  const hash = crypto
+    .createHash('sha512')
+    .update(input)
+    .digest('hex')
+    .slice(0, 64);
+  return `${CONTRACT_PREFIX}${hash}`;
+}
+
+export function computeContractRegistryAddress(name: string): string {
+  const hash = crypto
+    .createHash('sha512')
+    .update(name)
+    .digest('hex')
+    .slice(0, 64);
+  return `${CONTRACT_REGISTRY_PREFIX}${hash}`;
+}

--- a/src/transactions/signing/context.ts
+++ b/src/transactions/signing/context.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PrivateKey, PublicKey } from './index';
+
+export default interface IContext {
+  getAlgorithmName: () => string;
+  sign: (message: Uint8Array, privateKey: PrivateKey) => string;
+  verify: (signature: string, message: Uint8Array, key: PublicKey) => boolean;
+  getPublicKey: (privateKey: PrivateKey) => PublicKey;
+  newRandomPrivateKey: () => PrivateKey;
+}

--- a/src/transactions/signing/index.ts
+++ b/src/transactions/signing/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as IContext } from './context';
+export { default as PrivateKey } from './privateKey';
+export { default as PublicKey } from './publicKey';
+export { default as ISigner } from './signer';
+
+export {
+  Context as Secp256k1Context,
+  PrivateKey as Secp256k1PrivateKey,
+  PublicKey as Secp256k1PublicKey,
+  Signer as Secp256k1Signer
+} from './secp256k1';
+
+export function toHex(buffer: Uint8Array): string {
+  return Array.from(buffer)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/src/transactions/signing/privateKey.ts
+++ b/src/transactions/signing/privateKey.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { toHex } from './index';
+
+interface IPrivateKey {
+  asHex: () => string;
+  asBytes: () => Buffer;
+}
+
+export default class PrivateKey implements IPrivateKey {
+  privateKey: Uint8Array;
+
+  static fromHex(privateKey: string): PrivateKey {
+    const buffer = Buffer.from(privateKey, 'hex');
+    return new this(Uint8Array.from(buffer));
+  }
+
+  constructor(privateKey: Uint8Array) {
+    this.privateKey = privateKey;
+  }
+
+  asHex(): string {
+    return toHex(this.privateKey);
+  }
+
+  asBytes(): Buffer {
+    return Buffer.from(this.privateKey);
+  }
+}

--- a/src/transactions/signing/publicKey.ts
+++ b/src/transactions/signing/publicKey.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { toHex } from './index';
+
+interface IPublicKey {
+  publicKey: Uint8Array;
+  asHex: () => string;
+  asBytes: () => Buffer;
+}
+
+export default class PublicKey implements IPublicKey {
+  publicKey: Uint8Array;
+
+  static fromHex(publicKey: string): PublicKey {
+    const buffer = Buffer.from(publicKey, 'hex');
+    return new this(Uint8Array.from(buffer));
+  }
+
+  constructor(publicKey: Uint8Array) {
+    this.publicKey = publicKey;
+  }
+
+  asHex(): string {
+    return toHex(this.publicKey);
+  }
+
+  asBytes(): Buffer {
+    return Buffer.from(this.publicKey);
+  }
+}

--- a/src/transactions/signing/secp256k1/context.ts
+++ b/src/transactions/signing/secp256k1/context.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import crypto, { randomBytes } from 'crypto';
+import secp256k1 from 'secp256k1';
+
+import { IContext, toHex } from '../index';
+import { PrivateKey, PublicKey } from './index';
+
+export default class Secp256k1Context implements IContext {
+  getAlgorithmName(): string {
+    return 'secp256k1';
+  }
+
+  sign(message: Uint8Array, privateKey: PrivateKey): string {
+    const hash = crypto
+      .createHash('sha256')
+      .update(message)
+      .digest();
+
+    const result = secp256k1.sign(hash, Buffer.from(privateKey.asBytes()));
+    return toHex(result.signature);
+  }
+
+  verify(signature: string, message: Uint8Array, key: PublicKey): boolean {
+    const hash = crypto
+      .createHash('sha256')
+      .update(message)
+      .digest();
+
+    const verified = secp256k1.verify(
+      hash,
+      Buffer.from(signature, 'hex'),
+      key.asBytes()
+    );
+    return verified ? true : false;
+  }
+
+  getPublicKey(privateKey: PrivateKey): PublicKey {
+    return new PublicKey(secp256k1.publicKeyCreate(privateKey.asBytes()));
+  }
+
+  newRandomPrivateKey(): PrivateKey {
+    let privateKey;
+    do {
+      privateKey = randomBytes(32);
+    } while (!secp256k1.privateKeyVerify(privateKey));
+
+    return new PrivateKey(privateKey);
+  }
+}

--- a/src/transactions/signing/secp256k1/index.spec.ts
+++ b/src/transactions/signing/secp256k1/index.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PrivateKey from './privateKey';
+import PublicKey from './publicKey';
+import Signer from './signer';
+
+const KEY1_PRIV_HEX =
+  '2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088';
+const KEY1_PUB_HEX =
+  '026a2c795a9776f75464aa3bda3534c3154a6e91b357b1181d3f515110f84b67c5';
+
+const KEY2_PRIV_HEX =
+  '51b845c2cdde22fe646148f0b51eaf5feec8c82ee921d5e0cbe7619f3bb9c62d';
+const KEY2_PUB_HEX =
+  '039c20a66b4ec7995391dbec1d8bb0e2c6e6fd63cd259ed5b877cb4ea98858cf6d';
+
+const MSG1 = 'test';
+const MSG1_KEY1_SIG =
+  '5195115d9be2547b720ee74c23dd841842875db6eae1f5da8605b050a49e' +
+  '702b4aa83be72ab7e3cb20f17c657011b49f4c8632be2745ba4de79e6aa0' +
+  '5da57b35';
+
+describe('Secp256k1', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('PrivateKey', () => {
+    it('should parse private hex keys', () => {
+      const privateKey = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      expect(privateKey.asHex()).toEqual(KEY1_PRIV_HEX);
+    });
+  });
+  describe('Signer', () => {
+    it('should return correct public key from private', () => {
+      const key1 = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const key2 = PrivateKey.fromHex(KEY2_PRIV_HEX);
+      const signer1 = new Signer(key1);
+      const signer2 = new Signer(key2);
+
+      expect(KEY1_PUB_HEX).toEqual(signer1.getPublicKey().asHex());
+      expect(KEY2_PUB_HEX).toEqual(signer2.getPublicKey().asHex());
+    });
+    it('should correctly produce a signature', () => {
+      const key = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const signer = new Signer(key);
+
+      const signature = signer.sign(Uint8Array.from(Buffer.from(MSG1)));
+      expect(MSG1_KEY1_SIG).toEqual(signature);
+    });
+    it('should verify on a correct public key', () => {
+      const key = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const signer = new Signer(key);
+
+      const publicKey = PublicKey.fromHex(KEY1_PUB_HEX);
+
+      expect(KEY1_PUB_HEX).toEqual(signer.getPublicKey().asHex());
+
+      const signature = signer.sign(Uint8Array.from(Buffer.from(MSG1)));
+      const result = signer.context.verify(
+        signature,
+        Uint8Array.from(Buffer.from(MSG1)),
+        publicKey
+      );
+      expect(result).toEqual(true);
+    });
+    it('should fail to verify on an incorrect public key', () => {
+      const key = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const signer = new Signer(key);
+
+      const publicKey = PublicKey.fromHex(KEY2_PUB_HEX);
+
+      expect(KEY1_PUB_HEX).toEqual(signer.getPublicKey().asHex());
+
+      const signature = signer.sign(Uint8Array.from(Buffer.from(MSG1)));
+      const result = signer.context.verify(
+        signature,
+        Uint8Array.from(Buffer.from(MSG1)),
+        publicKey
+      );
+      expect(result).toEqual(false);
+    });
+    it('should return the algorithm name', () => {
+      const key = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const signer = new Signer(key);
+
+      expect('secp256k1').toEqual(signer.context.getAlgorithmName());
+    });
+  });
+});

--- a/src/transactions/signing/secp256k1/index.ts
+++ b/src/transactions/signing/secp256k1/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as Context } from './context';
+export { default as PrivateKey } from './privateKey';
+export { default as PublicKey } from './publicKey';
+export { default as Signer } from './signer';

--- a/src/transactions/signing/secp256k1/privateKey.ts
+++ b/src/transactions/signing/secp256k1/privateKey.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PrivateKey, toHex } from '../index';
+
+export default class Secp256k1PrivateKey extends PrivateKey {
+  static fromHex(privateKey: string): Secp256k1PrivateKey {
+    const buffer = Buffer.from(privateKey, 'hex');
+    return new this(Uint8Array.from(buffer));
+  }
+
+  constructor(privateKey: Uint8Array) {
+    super(privateKey);
+  }
+
+  asHex(): string {
+    return toHex(this.privateKey);
+  }
+
+  asBytes(): Buffer {
+    return Buffer.from(this.privateKey);
+  }
+}

--- a/src/transactions/signing/secp256k1/publicKey.ts
+++ b/src/transactions/signing/secp256k1/publicKey.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PublicKey } from '../index';
+
+export default class Secp256k1PublicKey extends PublicKey {
+  publicKey: Uint8Array;
+
+  static fromHex(publicKey: string): PublicKey {
+    const buffer = Buffer.from(publicKey, 'hex');
+    return new this(Uint8Array.from(buffer));
+  }
+
+  constructor(publicKey: Uint8Array) {
+    super(publicKey);
+  }
+}

--- a/src/transactions/signing/secp256k1/signer.ts
+++ b/src/transactions/signing/secp256k1/signer.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISigner } from '../index';
+import { Context, PrivateKey, PublicKey } from './index';
+
+export default class Secp256k1Signer implements ISigner {
+  context: Context;
+
+  privateKey: PrivateKey;
+
+  constructor(privateKey: PrivateKey) {
+    this.privateKey = privateKey;
+    this.context = new Context();
+  }
+
+  sign(message: Uint8Array): string {
+    return this.context.sign(message, this.privateKey);
+  }
+
+  getPublicKey(): PublicKey {
+    return this.context.getPublicKey(this.privateKey);
+  }
+}

--- a/src/transactions/signing/signer.ts
+++ b/src/transactions/signing/signer.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PrivateKey, PublicKey } from './index';
+
+export default interface ISigner {
+  privateKey: PrivateKey;
+
+  sign: (message: Uint8Array) => string;
+
+  getPublicKey: () => PublicKey;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015", "dom"],
+    "esModuleInterop": true,
+    "declaration": true,
+    "resolveJsonModule": true,
+    "allowJs": true
+  },
+  "exclude": ["node_modules", "**/*.spec.ts"],
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
This adds addressing utility functions as well as default and Secp256k1 implementations of the Signer, Context, PrivateKey, and PublicKey classes and interfaces. It also includes tests for the Secp256k1 implementation. These tests can be run from the project root with the command `npm run test`.