### PR TITLE
Add protos

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "license": "Apache-2.0",
   "scripts": {
     "format": "prettier --write \"**/*.+(ts|*rc|json|js)\"",
-    "lint": "eslint src/**/**/**/*"
+    "lint": "eslint src/**/**/**/*",
+    "postinstall": "npm run generate-proto-files",
+    "generate-proto-files": "node scripts/compile_protobuf.js ./protos"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.14.0",
@@ -24,7 +26,13 @@
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
+    "fs": "0.0.1-security",
+    "path": "^0.12.7",
     "prettier": "^1.19.1",
+    "process": "^0.11.10",
     "typescript": "^3.7.4"
+  },
+  "dependencies": {
+    "protobufjs": "^6.8.8"
   }
 }

--- a/protos/batch.proto
+++ b/protos/batch.proto
@@ -1,0 +1,47 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "transaction.proto";
+
+message BatchHeader {
+    // Public key for the client that signed the BatchHeader
+    string signer_public_key = 1;
+
+    // List of transaction.header_signatures that match the order of
+    // transactions required for the batch
+    repeated string transaction_ids = 2;
+}
+
+message Batch {
+    // The serialized version of the BatchHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // A list of the transactions that match the list of
+    // transaction_ids listed in the batch header
+    repeated Transaction transactions = 3;
+
+    // A debugging flag which indicates this batch should be traced through the
+    // system, resulting in a higher level of debugging output.
+    bool trace = 4;
+}
+
+message BatchList {
+    repeated Batch batches = 1;
+}

--- a/protos/sabre_payload.proto
+++ b/protos/sabre_payload.proto
@@ -1,0 +1,153 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+message SabrePayload {
+  enum Action {
+    ACTION_UNSET = 0;
+    CREATE_CONTRACT = 1;
+    DELETE_CONTRACT = 2;
+    EXECUTE_CONTRACT = 3;
+    CREATE_CONTRACT_REGISTRY = 4;
+    DELETE_CONTRACT_REGISTRY = 5;
+    UPDATE_CONTRACT_REGISTRY_OWNERS = 6;
+    CREATE_NAMESPACE_REGISTRY = 7;
+    DELETE_NAMESPACE_REGISTRY = 8;
+    UPDATE_NAMESPACE_REGISTRY_OWNERS = 9;
+    CREATE_NAMESPACE_REGISTRY_PERMISSION = 10;
+    DELETE_NAMESPACE_REGISTRY_PERMISSION = 11;
+    CREATE_SMART_PERMISSION = 12;
+    UPDATE_SMART_PERMISSION= 13;
+    DELETE_SMART_PERMISSION = 14;
+  }
+
+  Action action = 1;
+
+  CreateContractAction create_contract = 2;
+  DeleteContractAction delete_contract = 3;
+  ExecuteContractAction execute_contract = 4;
+
+  CreateContractRegistryAction create_contract_registry = 5;
+  DeleteContractRegistryAction delete_contract_registry = 6;
+  UpdateContractRegistryOwnersAction update_contract_registry_owners = 7;
+
+  CreateNamespaceRegistryAction create_namespace_registry = 8;
+  DeleteNamespaceRegistryAction delete_namespace_registry = 9;
+  UpdateNamespaceRegistryOwnersAction update_namespace_registry_owners = 10;
+  CreateNamespaceRegistryPermissionAction create_namespace_registry_permission = 11;
+  DeleteNamespaceRegistryPermissionAction delete_namespace_registry_permission = 12;
+
+  CreateSmartPermissionAction create_smart_permission = 13;
+  UpdateSmartPermissionAction update_smart_permission = 14;
+  DeleteSmartPermissionAction delete_smart_permission = 15;
+}
+
+// creates a Contract and updates ContractRegistry with a version entry
+message CreateContractAction {
+  string name = 1;
+  string version = 2;
+  repeated string inputs = 3;
+  repeated string outputs = 4;
+  bytes contract = 5;
+}
+
+// removes a Contract and removes the version entry from ContractRegistry
+message DeleteContractAction {
+  string name = 1;
+  string version = 2;
+}
+
+// executes the contract
+message ExecuteContractAction {
+  string name = 1;
+  string version = 2;
+  repeated string inputs = 3;
+  repeated string outputs = 4;
+  bytes payload = 5;
+}
+
+// creates the ContractRegistry in state with no Versions
+message CreateContractRegistryAction {
+  string name = 1;
+  repeated string owners = 2;
+}
+
+// deletes the ContractRegistry associated with 'name'
+// only if it contains no versions
+message DeleteContractRegistryAction {
+  string name = 1;
+}
+
+// updates the owners field in the ContractRegistry associated with 'name'
+message UpdateContractRegistryOwnersAction {
+  string name = 1;
+  repeated string owners = 2;
+}
+
+// creates the ContractRegistry in state with no Permissions
+message CreateNamespaceRegistryAction {
+  string namespace = 1;
+  repeated string owners = 2;
+}
+
+// deletes the NamespaceRegistry associated with 'namespace'
+// only if it contains no permissions
+message DeleteNamespaceRegistryAction {
+  string namespace = 1;
+}
+
+// updates the owners field in the NamespaceRegistry associated with 'namespace'
+message UpdateNamespaceRegistryOwnersAction {
+  string namespace = 1;
+  repeated string owners = 2;
+}
+
+// adds a permission entry to the NamespaceRegistry associated with 'namespace'
+message CreateNamespaceRegistryPermissionAction {
+  string namespace = 1;
+  string contract_name = 2;
+  bool read = 3;
+  bool write = 4;
+}
+
+// removes a permission entry to the NamespaceRegistry associated with
+// 'namespace'
+message DeleteNamespaceRegistryPermissionAction {
+  string namespace = 1;
+  string contract_name = 2;
+}
+
+// Creates a smart permission
+message CreateSmartPermissionAction {
+  string name = 1;
+  // ID of organization that owns the smart permission
+  string org_id = 2;
+  bytes function = 3;
+}
+
+// Updates a smart permission
+message UpdateSmartPermissionAction {
+  string name = 1;
+  // ID of organization that owns the smart permission
+  string org_id = 2;
+  bytes function = 3;
+}
+
+// Deletes  a smart permission
+message DeleteSmartPermissionAction {
+  string name = 1;
+  // ID of organization that owns the smart permission
+  string org_id = 2;
+}

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -1,0 +1,69 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message TransactionHeader {
+    // Public key for the client who added this transaction to a batch
+    string batcher_public_key = 1;
+
+    // A list of transaction signatures that describe the transactions that
+    // must be processed before this transaction can be valid
+    repeated string dependencies = 2;
+
+    // The family name correlates to the transaction processor's family name
+    // that this transaction can be processed on, for example 'intkey'
+    string family_name = 3;
+
+    // The family version correlates to the transaction processor's family
+    // version that this transaction can be processed on, for example "1.0"
+    string family_version = 4;
+
+    // A list of addresses that are given to the context manager and control
+    // what addresses the transaction processor is allowed to read from.
+    repeated string inputs = 5;
+
+    // A random string that provides uniqueness for transactions with
+    // otherwise identical fields.
+    string nonce = 6;
+
+    // A list of addresses that are given to the context manager and control
+    // what addresses the transaction processor is allowed to write to.
+    repeated string outputs = 7;
+
+    //The sha512 hash of the encoded payload
+    string payload_sha512 = 9;
+
+    // Public key for the client that signed the TransactionHeader
+    string signer_public_key = 10;
+}
+
+message Transaction {
+    // The serialized version of the TransactionHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // The payload is the encoded family specific information of the
+    // transaction. Example cbor({'Verb': verb, 'Name': name,'Value': value})
+    bytes payload = 3;
+}
+
+// A simple list of transactions that needs to be serialized before
+// it can be transmitted to a batcher.
+message TransactionList {
+    repeated Transaction transactions = 1;
+}

--- a/scripts/compile_protobuf.js
+++ b/scripts/compile_protobuf.js
@@ -1,0 +1,56 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const fs = require('fs');
+const pbjs = require('protobufjs/cli/pbjs');
+const pbts = require('protobufjs/cli/pbts');
+const process = require('process');
+
+const path = require('path');
+
+const protoDir = process.argv[2];
+
+const files = fs.readdirSync(protoDir).map(f => path.resolve(protoDir, f));
+
+pbjs.main(
+  [
+    '-t',
+    'static-module',
+    '-w',
+    'commonjs',
+    '-o',
+    'src/compiled_protos.js',
+    ...files
+  ],
+  function handleJsCompileError(err) {
+    if (err) {
+      console.error(`Error compiling protobuf bundle: ${err}`);
+    } else {
+      console.log('Sucessfully created protobuf bundle');
+    }
+  }
+);
+
+pbts.main(
+  ['-o', 'src/compiled_protos.d.ts', 'src/compiled_protos.js'],
+  function handleJsCompileError(err) {
+    if (err) {
+      console.error(`Error compiling protobuf typings: ${err}`);
+    } else {
+      console.log('Sucessfully created protobuf typings');
+    }
+  }
+);


### PR DESCRIPTION
Adds transaction, batch, and sabre_payload protos. Also, adds proto compilation script and postinstall script.

## Testing

running `npm install` from the project root should install the required packages and generate the compiled protobuf bundles in `src/`