### PR TITLE
Add signing utils

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -14,10 +14,16 @@
   "repository": "https://github.com/hyperledger/transact-sdk-javascript.git",
   "license": "Apache-2.0",
   "scripts": {
+    "postinstall": "npm run generate-proto-files",
     "format": "prettier --write \"**/*.+(ts|*rc|json|js)\"",
     "lint": "eslint src/**/**/**/*",
-    "postinstall": "npm run generate-proto-files",
     "generate-proto-files": "node scripts/compile_protobuf.js ./protos"
+  },
+  "dependencies": {
+    "@types/secp256k1": "^3.5.0",
+    "crypto": "^1.0.1",
+    "protobufjs": "^6.8.8",
+    "secp256k1": "^3.8.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.14.0",
@@ -31,8 +37,5 @@
     "prettier": "^1.19.1",
     "process": "^0.11.10",
     "typescript": "^3.7.4"
-  },
-  "dependencies": {
-    "protobufjs": "^6.8.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "postinstall": "npm run generate-proto-files",
     "format": "prettier --write \"**/*.+(ts|*rc|json|js)\"",
     "lint": "eslint src/**/**/**/*",
+    "test": "jest",
     "generate-proto-files": "node scripts/compile_protobuf.js ./protos"
   },
   "dependencies": {
@@ -26,16 +27,23 @@
     "secp256k1": "^3.8.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.7.7",
+    "@babel/preset-env": "^7.7.7",
+    "@babel/preset-typescript": "^7.7.7",
+    "@types/jest": "^24.0.25",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
+    "babel-jest": "^24.9.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
     "fs": "0.0.1-security",
+    "jest": "^24.9.0",
     "path": "^0.12.7",
     "prettier": "^1.19.1",
     "process": "^0.11.10",
+    "ts-jest": "^24.2.0",
     "typescript": "^3.7.4"
   }
 }

--- a/src/transactions/signing/context.ts
+++ b/src/transactions/signing/context.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PrivateKey, PublicKey } from './index';
+
+export default interface IContext {
+  getAlgorithmName: () => string;
+  sign: (message: Uint8Array, privateKey: PrivateKey) => string;
+  verify: (signature: string, message: Uint8Array, key: PublicKey) => boolean;
+  getPublicKey: (privateKey: PrivateKey) => PublicKey;
+  newRandomPrivateKey: () => PrivateKey;
+}

--- a/src/transactions/signing/index.ts
+++ b/src/transactions/signing/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as IContext } from './context';
+export { default as PrivateKey } from './privateKey';
+export { default as PublicKey } from './publicKey';
+export { default as ISigner } from './signer';
+
+export {
+  Context as Secp256k1Context,
+  PrivateKey as Secp256k1PrivateKey,
+  PublicKey as Secp256k1PublicKey,
+  Signer as Secp256k1Signer
+} from './secp256k1';
+
+/**
+ * Converts a buffer to its hex representation
+ * @param {Uint8Array} buffer the buffer to convert
+ * @return {string} the hex representation of the buffer
+ */
+export function toHex(buffer: Uint8Array): string {
+  return Array.from(buffer)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/src/transactions/signing/privateKey.ts
+++ b/src/transactions/signing/privateKey.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { toHex } from './index';
+
+interface IPrivateKey {
+  asHex: () => string;
+  asBytes: () => Buffer;
+}
+
+export default class PrivateKey implements IPrivateKey {
+  privateKey: Uint8Array;
+
+  /**
+   * converts a hex representation of a private key into a PrivateKey
+   * @param {string} privateKey hex representation of a private key
+   * @return {PrivateKey}
+   */
+  static fromHex(privateKey: string): PrivateKey {
+    const buffer = Buffer.from(privateKey, 'hex');
+    return new this(Uint8Array.from(buffer));
+  }
+
+  constructor(privateKey: Uint8Array) {
+    this.privateKey = privateKey;
+  }
+
+  /**
+   * converts a PrivateKey to its hex representation
+   * @return {string} hex representation of the PrivateKey
+   */
+  asHex(): string {
+    return toHex(this.privateKey);
+  }
+
+  /**
+   * converts a PrivateKey to its byte representation
+   * @return {Buffer} byte representation of the PrivateKey
+   */
+  asBytes(): Buffer {
+    return Buffer.from(this.privateKey);
+  }
+}

--- a/src/transactions/signing/publicKey.ts
+++ b/src/transactions/signing/publicKey.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { toHex } from './index';
+
+interface IPublicKey {
+  publicKey: Uint8Array;
+  asHex: () => string;
+  asBytes: () => Buffer;
+}
+
+export default class PublicKey implements IPublicKey {
+  publicKey: Uint8Array;
+
+  /**
+   * converts a hex representation of a public key to a PublicKey
+   * @param {string} publicKey hex representation of a public key
+   * @return {PublicKey}
+   */
+  static fromHex(publicKey: string): PublicKey {
+    const buffer = Buffer.from(publicKey, 'hex');
+    return new this(Uint8Array.from(buffer));
+  }
+
+  constructor(publicKey: Uint8Array) {
+    this.publicKey = publicKey;
+  }
+
+  /**
+   * converts a PublicKey to its hex representation
+   * @return {string} hex representation of a PublicKey
+   */
+  asHex(): string {
+    return toHex(this.publicKey);
+  }
+
+  /**
+   * converts a PublicKey to its byte representation
+   * @return {Buffer} byte representation of a PublicKey
+   */
+  asBytes(): Buffer {
+    return Buffer.from(this.publicKey);
+  }
+}

--- a/src/transactions/signing/secp256k1/context.ts
+++ b/src/transactions/signing/secp256k1/context.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import crypto, { randomBytes } from 'crypto';
+import secp256k1 from 'secp256k1';
+
+import { IContext, toHex } from '../index';
+import { PrivateKey, PublicKey } from './index';
+
+export default class Secp256k1Context implements IContext {
+  getAlgorithmName(): string {
+    return 'secp256k1';
+  }
+
+  /**
+   * Signs a transaction
+   * @param {Uint8Array} message the message to sign
+   * @param {PrivateKey} privateKey the signer's private key
+   * @return {string} the signed message as hex
+   */
+  sign(message: Uint8Array, privateKey: PrivateKey): string {
+    const hash = crypto
+      .createHash('sha256')
+      .update(message)
+      .digest();
+
+    const result = secp256k1.sign(hash, Buffer.from(privateKey.asBytes()));
+    return toHex(result.signature);
+  }
+
+  /**
+   * Verifies that a transaction is serialized and signed correctly
+   * @param {string} signature hex representation of the signature
+   * @param {Uint8Array} message the message to verify
+   * @param {PublicKey} key the public key to verify against
+   * @return {boolean} true if message is verifies, otherwise, false.
+   */
+  verify(signature: string, message: Uint8Array, key: PublicKey): boolean {
+    const hash = crypto
+      .createHash('sha256')
+      .update(message)
+      .digest();
+
+    const verified = secp256k1.verify(
+      hash,
+      Buffer.from(signature, 'hex'),
+      key.asBytes()
+    );
+    return verified ? true : false;
+  }
+
+  /**
+   * Gets a Public Key from a given Private Key
+   * @param {PrivateKey} privateKey a Private Key
+   * @return {PublicKey} A Public Key for the given private key
+   */
+  getPublicKey(privateKey: PrivateKey): PublicKey {
+    return new PublicKey(secp256k1.publicKeyCreate(privateKey.asBytes()));
+  }
+
+  /**
+   * generates a new Private Key
+   * @return {PrivateKey} a new Private Key
+   */
+  newRandomPrivateKey(): PrivateKey {
+    let privateKey;
+    do {
+      privateKey = randomBytes(32);
+    } while (!secp256k1.privateKeyVerify(privateKey));
+
+    return new PrivateKey(privateKey);
+  }
+}

--- a/src/transactions/signing/secp256k1/index.spec.ts
+++ b/src/transactions/signing/secp256k1/index.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PrivateKey from './privateKey';
+import PublicKey from './publicKey';
+import Signer from './signer';
+
+const KEY1_PRIV_HEX =
+  '2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088';
+const KEY1_PUB_HEX =
+  '026a2c795a9776f75464aa3bda3534c3154a6e91b357b1181d3f515110f84b67c5';
+
+const KEY2_PRIV_HEX =
+  '51b845c2cdde22fe646148f0b51eaf5feec8c82ee921d5e0cbe7619f3bb9c62d';
+const KEY2_PUB_HEX =
+  '039c20a66b4ec7995391dbec1d8bb0e2c6e6fd63cd259ed5b877cb4ea98858cf6d';
+
+const MSG1 = 'test';
+const MSG1_KEY1_SIG =
+  '5195115d9be2547b720ee74c23dd841842875db6eae1f5da8605b050a49e' +
+  '702b4aa83be72ab7e3cb20f17c657011b49f4c8632be2745ba4de79e6aa0' +
+  '5da57b35';
+
+describe('Secp256k1', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('PrivateKey', () => {
+    it('should parse private hex keys', () => {
+      const privateKey = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      expect(privateKey.asHex()).toEqual(KEY1_PRIV_HEX);
+    });
+  });
+  describe('Signer', () => {
+    it('should return correct public key from private', () => {
+      const key1 = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const key2 = PrivateKey.fromHex(KEY2_PRIV_HEX);
+      const signer1 = new Signer(key1);
+      const signer2 = new Signer(key2);
+
+      expect(KEY1_PUB_HEX).toEqual(signer1.getPublicKey().asHex());
+      expect(KEY2_PUB_HEX).toEqual(signer2.getPublicKey().asHex());
+    });
+    it('should correctly produce a signature', () => {
+      const key = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const signer = new Signer(key);
+
+      const signature = signer.sign(Uint8Array.from(Buffer.from(MSG1)));
+      expect(MSG1_KEY1_SIG).toEqual(signature);
+    });
+    it('should verify on a correct public key', () => {
+      const key = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const signer = new Signer(key);
+
+      const publicKey = PublicKey.fromHex(KEY1_PUB_HEX);
+
+      expect(KEY1_PUB_HEX).toEqual(signer.getPublicKey().asHex());
+
+      const signature = signer.sign(Uint8Array.from(Buffer.from(MSG1)));
+      const result = signer.context.verify(
+        signature,
+        Uint8Array.from(Buffer.from(MSG1)),
+        publicKey
+      );
+      expect(result).toEqual(true);
+    });
+    it('should fail to verify on an incorrect public key', () => {
+      const key = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const signer = new Signer(key);
+
+      const publicKey = PublicKey.fromHex(KEY2_PUB_HEX);
+
+      expect(KEY1_PUB_HEX).toEqual(signer.getPublicKey().asHex());
+
+      const signature = signer.sign(Uint8Array.from(Buffer.from(MSG1)));
+      const result = signer.context.verify(
+        signature,
+        Uint8Array.from(Buffer.from(MSG1)),
+        publicKey
+      );
+      expect(result).toEqual(false);
+    });
+    it('should return the algorithm name', () => {
+      const key = PrivateKey.fromHex(KEY1_PRIV_HEX);
+      const signer = new Signer(key);
+
+      expect('secp256k1').toEqual(signer.context.getAlgorithmName());
+    });
+  });
+});

--- a/src/transactions/signing/secp256k1/index.ts
+++ b/src/transactions/signing/secp256k1/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as Context } from './context';
+export { default as PrivateKey } from './privateKey';
+export { default as PublicKey } from './publicKey';
+export { default as Signer } from './signer';

--- a/src/transactions/signing/secp256k1/privateKey.ts
+++ b/src/transactions/signing/secp256k1/privateKey.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PrivateKey, toHex } from '../index';
+
+export default class Secp256k1PrivateKey extends PrivateKey {
+  /**
+   * Creates a Secp256k1PrivateKey from a hex string
+   * @param {string} privateKey a hex representation of a private key
+   * @return {Secp256k1PrivateKey}
+   */
+  static fromHex(privateKey: string): Secp256k1PrivateKey {
+    const buffer = Buffer.from(privateKey, 'hex');
+    return new this(Uint8Array.from(buffer));
+  }
+
+  constructor(privateKey: Uint8Array) {
+    super(privateKey);
+  }
+
+  /**
+   * converts a Secp256k1PrivateKey to its hex representation
+   * @return {string} the hex representation of the private key
+   */
+  asHex(): string {
+    return toHex(this.privateKey);
+  }
+
+  /**
+   * converts a Secp256k1PrivateKey to its byte representation
+   * @return {Buffer} byte representation of the private key
+   */
+  asBytes(): Buffer {
+    return Buffer.from(this.privateKey);
+  }
+}

--- a/src/transactions/signing/secp256k1/publicKey.ts
+++ b/src/transactions/signing/secp256k1/publicKey.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PublicKey } from '../index';
+
+export default class Secp256k1PublicKey extends PublicKey {
+  publicKey: Uint8Array;
+
+  /**
+   * creates a Secp256k1PublicKey from a hex string
+   * @param {string} publicKey hex representation of a public key
+   * @return {PublicKey} a Secp256k1 public key
+   */
+  static fromHex(publicKey: string): PublicKey {
+    const buffer = Buffer.from(publicKey, 'hex');
+    return new this(Uint8Array.from(buffer));
+  }
+
+  constructor(publicKey: Uint8Array) {
+    super(publicKey);
+  }
+}

--- a/src/transactions/signing/secp256k1/signer.ts
+++ b/src/transactions/signing/secp256k1/signer.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISigner } from '../index';
+import { Context, PrivateKey, PublicKey } from './index';
+
+export default class Secp256k1Signer implements ISigner {
+  context: Context;
+
+  privateKey: PrivateKey;
+
+  constructor(privateKey: PrivateKey) {
+    this.privateKey = privateKey;
+    this.context = new Context();
+  }
+
+  /**
+   * Signs a message with a Secp256k1 private key
+   * @param {Uint8Array} message the message to sign
+   * @return {string} the signed message
+   */
+  sign(message: Uint8Array): string {
+    return this.context.sign(message, this.privateKey);
+  }
+
+  /**
+   * gets the public key associated with the signer
+   * @return {PublicKey} the public key associated with the signer
+   */
+  getPublicKey(): PublicKey {
+    return this.context.getPublicKey(this.privateKey);
+  }
+}

--- a/src/transactions/signing/signer.ts
+++ b/src/transactions/signing/signer.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PrivateKey, PublicKey } from './index';
+
+export default interface ISigner {
+  privateKey: PrivateKey;
+
+  sign: (message: Uint8Array) => string;
+
+  getPublicKey: () => PublicKey;
+}


### PR DESCRIPTION
Adds default and secp256k1 interfaces and implementations for Signer, Context, PublicKey, and PrivateKey. This also adds tests using Jest for the sep256k1 implementations. 