### PR TITLE
Add Generic and Sabre transaction builders

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "generate-proto-files": "node scripts/compile_protobuf.js ./protos"
   },
   "dependencies": {
-    "@types/secp256k1": "^3.5.0",
+    "@types/secp256k1": "3.5.0",
     "crypto": "^1.0.1",
     "protobufjs": "^6.8.8",
-    "secp256k1": "^3.8.0"
+    "secp256k1": "3.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",

--- a/src/sabre/transaction/index.ts
+++ b/src/sabre/transaction/index.ts
@@ -14,15 +14,4 @@
  * limitations under the License.
  */
 
-export { MissingFieldError, TransactionBuildError } from './errors';
 export { default as TransactionBuilder } from './transactionBuilder';
-
-export {
-  TransactionBuilder as SabreTransactionBuilder
-} from '../../sabre/transaction';
-
-export interface Contract {
-  name: string;
-  version: string;
-  prefix: string;
-}

--- a/src/sabre/transaction/transactionBuilder.ts
+++ b/src/sabre/transaction/transactionBuilder.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import crypto from 'crypto';
+import {
+  calculateNamespaceRegistryAddress,
+  computeContractAddress,
+  computeContractRegistryAddress,
+} from '../addressing';
+import {
+  SABRE_FAMILY_NAME,
+  SABRE_FAMILY_VERSION
+} from '../index'
+import { Contract } from '../../transactions/transaction/index';
+import { TransactionBuilder } from '../../transactions/transaction/index';
+import { Signer } from '../../transactions/signing/secp256k1';
+import {
+  Transaction,
+  TransactionHeader,
+  ExecuteContractAction,
+  SabrePayload
+} from '../../compiled_protos';
+
+function prepareSabreInputs(
+  contractAddresses: string[],
+  contract: Contract
+): string[] {
+  return [
+    computeContractRegistryAddress(contract.name),
+    computeContractAddress(contract.name, contract.version),
+    calculateNamespaceRegistryAddress(contract.prefix),
+    ...contractAddresses
+  ];
+}
+
+export default class SabreTransactionBuilder extends TransactionBuilder {
+  contract: Contract;
+
+  constructor(contract: Contract) {
+    super();
+    this.contract = contract;
+  }
+
+  build(signer: Signer): Transaction {
+    const batcherPublicKey = this.batcherPublicKey
+      ? this.batcherPublicKey.asHex()
+      : signer.getPublicKey().asHex();
+
+    const executeTransactionAction = ExecuteContractAction.create({
+      name: this.contract.name,
+      version: this.contract.version,
+      inputs: this.inputs,
+      outputs: this.outputs,
+      payload: this.payload
+    });
+
+    const sabrePayload = SabrePayload.encode({
+      action: SabrePayload.Action.EXECUTE_CONTRACT,
+      executeContract: executeTransactionAction
+    }).finish();
+
+    const sabreTransactionHeader = TransactionHeader.encode({
+      familyName: SABRE_FAMILY_NAME,
+      familyVersion: SABRE_FAMILY_VERSION,
+      inputs: prepareSabreInputs(this.inputs, this.contract),
+      outputs: this.outputs,
+      signerPublicKey: signer.getPublicKey().asHex(),
+      batcherPublicKey,
+      dependencies: this.dependencies,
+      payloadSha512: crypto
+        .createHash('sha512')
+        .update(sabrePayload)
+        .digest('hex')
+    }).finish();
+
+    const headerSignature = signer.sign(sabreTransactionHeader);
+
+    return Transaction.create({
+      header: sabreTransactionHeader,
+      headerSignature,
+      payload: sabrePayload
+    });
+  }
+}

--- a/src/transactions/transaction/errors/index.ts
+++ b/src/transactions/transaction/errors/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as TransactionBuildError } from './transactionBuildError';
+export { default as MissingFieldError } from './missingFieldError';

--- a/src/transactions/transaction/errors/missingFieldError.ts
+++ b/src/transactions/transaction/errors/missingFieldError.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TransactionBuildError } from './index';
+
+export default class MissingFieldError extends TransactionBuildError {
+  field: string;
+
+  constructor(field: string) {
+    super(`Missing field: ${field}`);
+    this.name = 'MissingFieldError';
+    this.field = field;
+  }
+}

--- a/src/transactions/transaction/errors/transactionBuildError.ts
+++ b/src/transactions/transaction/errors/transactionBuildError.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default class TransactionBuildError extends Error {
+  name: string;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'TransactionBuildError';
+  }
+}

--- a/src/transactions/transaction/index.ts
+++ b/src/transactions/transaction/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { MissingFieldError, TransactionBuildError } from './errors';
+export { default as TransactionBuilder } from './transactionBuilder';
+
+export {
+  TransactionBuilder as SabreTransactionBuilder
+} from './sabre';
+
+export interface Contract {
+  name: string;
+  version: string;
+  prefix: string;
+}

--- a/src/transactions/transaction/transactionBuilder.ts
+++ b/src/transactions/transaction/transactionBuilder.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import crypto from 'crypto';
+import { Transaction, TransactionHeader } from '../../compiled_protos';
+import { PublicKey, Signer } from '../signing/secp256k1';
+import { MissingFieldError } from './errors';
+
+export default class TransactionBuilder {
+  batcherPublicKey: PublicKey | null;
+
+  dependencies: string[];
+
+  familyName: string;
+
+  familyVersion: string;
+
+  inputs: string[];
+
+  outputs: string[];
+
+  nonce: string | null;
+
+  payload: Uint8Array;
+
+  constructor() {
+    this.batcherPublicKey = null;
+    this.dependencies = [];
+    this.familyName = '';
+    this.familyVersion = '';
+    this.inputs = [];
+    this.outputs = [];
+    this.nonce = null;
+    this.payload = new Uint8Array();
+  }
+
+  withBatcherPublicKey(batcherPublicKey: PublicKey): TransactionBuilder {
+    this.batcherPublicKey = batcherPublicKey;
+    return this;
+  }
+
+  withDependencies(dependencies: string[]): TransactionBuilder {
+    this.dependencies = dependencies;
+    return this;
+  }
+
+  withFamilyName(familyName: string): TransactionBuilder {
+    this.familyName = familyName;
+    return this;
+  }
+
+  withFamilyVersion(self, familyVersion: string): TransactionBuilder {
+    this.familyVersion = familyVersion;
+    return this;
+  }
+
+  withInputs(inputs: string[]): TransactionBuilder {
+    this.inputs = inputs;
+    return this;
+  }
+
+  withOutputs(outputs: string[]): TransactionBuilder {
+    this.outputs = outputs;
+    return this;
+  }
+
+  withNonce(nonce: string): TransactionBuilder {
+    this.nonce = nonce;
+    return this;
+  }
+
+  withPayload(payloadBytes: Uint8Array): TransactionBuilder {
+    this.payload = payloadBytes;
+    return this;
+  }
+
+  buildTransactionHeader(signer: Signer): Uint8Array {
+    const batcherPublicKey = this.batcherPublicKey
+      ? this.batcherPublicKey.asHex()
+      : signer.getPublicKey().asHex();
+
+    if (this.familyName === '') {
+      throw new MissingFieldError('Family Name');
+    }
+
+    if (this.familyVersion === '') {
+      throw new MissingFieldError('Family Version');
+    }
+
+    if (!this.inputs.length) {
+      throw new MissingFieldError('Inputs');
+    }
+
+    if (!this.outputs.length) {
+      throw new MissingFieldError('Outputs');
+    }
+
+    if (!this.payload.length) {
+      throw new MissingFieldError('Payload');
+    }
+
+    return TransactionHeader.encode({
+      familyName: this.familyName,
+      familyVersion: this.familyVersion,
+      inputs: this.inputs,
+      outputs: this.outputs,
+      signerPublicKey: signer.getPublicKey().asHex(),
+      batcherPublicKey,
+      dependencies: this.dependencies,
+      nonce: this.nonce,
+      payloadSha512: crypto
+        .createHash('sha512')
+        .update(this.payload)
+        .digest('hex')
+    }).finish();
+  }
+
+  build(signer: Signer): Transaction {
+    const header = this.buildTransactionHeader(signer);
+
+    const headerSignature = signer.sign(header);
+
+    return Transaction.create({
+      header,
+      headerSignature,
+      payload: this.payload
+    });
+  }
+}


### PR DESCRIPTION
This PR adds transaction builder implementations for generic transactions and Sabre specific transactions. These can be used by applications to create transactions that can be added to batches and submitted.