### PR TITLE
Remove deprecated crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@types/secp256k1": "3.5.0",
-    "crypto": "^1.0.1",
     "protobufjs": "^6.8.8",
     "secp256k1": "3.8.0"
   },


### PR DESCRIPTION
This removes the deprecated crypto package in favor of the built-in
Node.js library.

Signed-off-by: Davey Newhall <newhall@bitwise.io>