### PR TITLE
Switch prePublish to prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "repository": "https://github.com/hyperledger/transact-sdk-javascript.git",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "tsc; node scripts/compile_protobuf.build.js ./protos",
+    "prepare": "tsc; node scripts/compile_protobuf.build.js ./protos",
     "format": "prettier --write \"**/*.+(ts|*rc|json|js)\"",
     "lint": "eslint src/**/**/**/*",
     "test": "jest",


### PR DESCRIPTION
This change allows for the project to be included via Git dependencies.

Signed-off-by: Davey Newhall <newhall@bitwise.io>