### PR TITLE
Fix BatchBuilder export

### DIFF
--- a/src/transactions/batch/batchBuilder.ts
+++ b/src/transactions/batch/batchBuilder.ts
@@ -23,7 +23,7 @@ import {
 import { Signer } from '../signing/secp256k1';
 import { MissingFieldError } from './errors';
 
-export class BatchBuilder {
+export default class BatchBuilder {
   transactions: Transaction[];
 
   trace: boolean;


### PR DESCRIPTION
Fixes issue with top level export of BatchBuilder by exporting default
as BatchBuilder following the same pattern as the rest of the SDK.
Signed-off-by: Davey Newhall <newhall@bitwise.io>