### PR TITLE
Fix withFamilyVersion function signature

### DIFF
--- a/src/transactions/transaction/transactionBuilder.ts
+++ b/src/transactions/transaction/transactionBuilder.ts
@@ -61,7 +61,7 @@ export default class TransactionBuilder {
     return this;
   }
 
-  withFamilyVersion(self, familyVersion: string): TransactionBuilder {
+  withFamilyVersion(familyVersion: string): TransactionBuilder {
     this.familyVersion = familyVersion;
     return this;
   }


### PR DESCRIPTION
This fixes a typo in the `.withFamilyVersion()` method signature in the `TransactionBuilder`

Signed-off-by: Davey Newhall <newhall@bitwise.io>