### PR TITLE
Update version

### DIFF
--- a/src/sabre/index.ts
+++ b/src/sabre/index.ts
@@ -18,4 +18,4 @@ export { TransactionBuilder as SabreTransactionBuilder } from './transaction';
 // The Sawtooth Sabre transaction family name (sabre)
 export const SABRE_FAMILY_NAME = 'sabre';
 // The Sawtooth Sabre transaction family version (0.4)
-export const SABRE_FAMILY_VERSION = '0.4';
+export const SABRE_FAMILY_VERSION = '0.5';

--- a/src/transactions/transaction/transactionBuilder.ts
+++ b/src/transactions/transaction/transactionBuilder.ts
@@ -61,7 +61,7 @@ export default class TransactionBuilder {
     return this;
   }
 
-  withFamilyVersion(self, familyVersion: string): TransactionBuilder {
+  withFamilyVersion(familyVersion: string): TransactionBuilder {
     this.familyVersion = familyVersion;
     return this;
   }


### PR DESCRIPTION
This updates the SABRE_FAMILY_VERSION constant to '0.5'. This was preventing Sabre transactions from being submitted successfully.